### PR TITLE
修复astro.config.mjs类型错误

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,6 +19,17 @@ import { remarkReadingTime } from './src/plugins/remark-reading-time.mjs';
 
 import svelte from "@astrojs/svelte";
 
+/**
+ * @typedef {Parameters<typeof AdmonitionComponent>[0]} AdmonitionProperties
+ * @typedef {Parameters<typeof AdmonitionComponent>[1]} AdmonitionChildren
+ * @typedef {Parameters<typeof AdmonitionComponent>[2]} AdmonitionType
+ */
+
+/**
+ * @type {(type: AdmonitionType) => (properties: AdmonitionProperties, children: AdmonitionChildren) => ReturnType<typeof AdmonitionComponent>}
+ */
+const admonition = (type) => (properties, children) => AdmonitionComponent(properties, children, type);
+
 
 // https://astro.build/config
 export default defineConfig({
@@ -65,11 +76,11 @@ export default defineConfig({
             github: GithubCardComponent,
             music: MusicCardComponent,
             quote: QuoteComponent,
-            note: (x, y) => AdmonitionComponent(x, y, "note"),
-            tip: (x, y) => AdmonitionComponent(x, y, "tip"),
-            important: (x, y) => AdmonitionComponent(x, y, "important"),
-            caution: (x, y) => AdmonitionComponent(x, y, "caution"),
-            warning: (x, y) => AdmonitionComponent(x, y, "warning"),
+            note: admonition("note"),
+            tip: admonition("tip"),
+            important: admonition("important"),
+            caution: admonition("caution"),
+            warning: admonition("warning"),
           },
         },
       ],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,7 @@ import rehypeKatex from 'rehype-katex';
 import remarkDirective from 'remark-directive';
 import rehypeComponents from "rehype-components";
 
-import { AdmonitionComponent } from "./src/plugins/rehype-component-admonition.mjs";
+import { admonition } from "./src/plugins/rehype-component-admonition.mjs";
 import { parseDirectiveNode } from "./src/plugins/remark-directive-rehype.js";
 import { MusicCardComponent } from "./src/plugins/rehype-component-music-card.mjs";
 import { GithubCardComponent } from './src/plugins/rehype-component-github-card.mjs';
@@ -18,18 +18,6 @@ import { remarkTypst } from './src/plugins/remark-typst.mjs';
 import { remarkReadingTime } from './src/plugins/remark-reading-time.mjs';
 
 import svelte from "@astrojs/svelte";
-
-/**
- * @typedef {Parameters<typeof AdmonitionComponent>[0]} AdmonitionProperties
- * @typedef {Parameters<typeof AdmonitionComponent>[1]} AdmonitionChildren
- * @typedef {Parameters<typeof AdmonitionComponent>[2]} AdmonitionType
- */
-
-/**
- * @type {(type: AdmonitionType) => (properties: AdmonitionProperties, children: AdmonitionChildren) => ReturnType<typeof AdmonitionComponent>}
- */
-const admonition = (type) => (properties, children) => AdmonitionComponent(properties, children, type);
-
 
 // https://astro.build/config
 export default defineConfig({

--- a/src/plugins/rehype-component-admonition.mjs
+++ b/src/plugins/rehype-component-admonition.mjs
@@ -31,3 +31,14 @@ export function AdmonitionComponent(properties, children, type) {
 		...children,
 	]);
 }
+
+/**
+ * @typedef {Parameters<typeof AdmonitionComponent>[0]} AdmonitionProperties
+ * @typedef {Parameters<typeof AdmonitionComponent>[1]} AdmonitionChildren
+ * @typedef {Parameters<typeof AdmonitionComponent>[2]} AdmonitionType
+ */
+
+/**
+ * @type {(type: AdmonitionType) => (properties: AdmonitionProperties, children: AdmonitionChildren) => ReturnType<typeof AdmonitionComponent>}
+ */
+export const admonition = (type) => (properties, children) => AdmonitionComponent(properties, children, type);


### PR DESCRIPTION
## 总结

修复 `astro.config.mjs` 中 admonition 组件回调参数 `x` 和 `y` 被提示为隐式 `any` 的问题。

## 修改

- 新增带 JSDoc 类型标注的 `admonition(type)` 包装函数
- 复用 `AdmonitionComponent` 的参数类型，避免手动写重复类型
- 将 `note`、`tip`、`important`、`caution`、`warning` 的内联回调替换为 `admonition(...)`